### PR TITLE
Removed need to rebuild containers after adding dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ build: | backend/data backend/.env
 	cd backend && docker build -t squadgoals-backend .
 	@echo "====== Rebuild Complete! ======"
 
+.PHONY: update
+update: 
+	@echo "====== Removing package_lock.json ======"
+	rm -f frontend/package_lock.json backend/package_lock.json
+	@echo "====== Reinstalling node_modules ======"
+	cd frontend && npm install
+	cd backend && npm install
+	@echo "====== NPM update complete! ======"
 
 .PHONY: clean
 clean:

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const cors = require("cors");
 
 const routes = require("./routes");
-const sequelize = require('./util/database')
+const sequelize = require("./util/database");
 const { appContext } = require("./middleware");
 const { authService } = require("./services");
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/frontend
-      - /frontend/node_modules
+      - ./frontend/node_modules:/frontend/node_modules
     links:
       - backend
     networks:
@@ -28,7 +28,7 @@ services:
       - "3100:3100"
     volumes:
       - ./backend:/backend
-      - /backend/node_modules
+      - ./backend/node_modules:/backend/node_modules
     networks:
       - squadgoalsnetwork
 


### PR DESCRIPTION
Small update with two changes which are big QoL updates:

1. It is **no longer necessary to rebuild when adding dependencies**, I've updated `docker-compose.yml` to just use your local node_modules. So if you run npm install it'll work in the container as well.
2. Added **`make update`** command. This is just a shortcut that deletes package-lock.json (a common cause of npm install not working) and runs npm install for both front and backend.

**tl;dr** no more 20 minute rebuilds because you added one library, I added `make update` so you never have a reason to leave the project root on the command line